### PR TITLE
fix(deps): Upgrade VeraId lib to support Android API level < 27

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:$bouncy_castle_version"
 
     // VeraId
-    implementation 'tech.relaycorp:veraid:1.10.3'
+    implementation 'tech.relaycorp:veraid:1.10.4'
 
     // Compose
     implementation platform('androidx.compose:compose-bom:2023.10.00')


### PR DESCRIPTION
See: https://github.com/relaycorp/veraid-jvm/pull/66
