### PR TITLE
fix: LTAND-179: fix navigation issue

### DIFF
--- a/app/src/main/java/tech/relaycorp/letro/main/MainViewModel.kt
+++ b/app/src/main/java/tech/relaycorp/letro/main/MainViewModel.kt
@@ -156,7 +156,7 @@ class MainViewModel @Inject constructor(
                     currentAccount.status == AccountStatus.ERROR -> RootNavigationScreen.AccountCreationFailed
                     !contactsState.isPairRequestWasEverSent -> RootNavigationScreen.WelcomeToLetro(
                         withAnimation = navigationHandledWithLastAccount == currentAccount.id &&
-                            (_rootNavigationScreen.value == RootNavigationScreen.AccountCreationWaiting || _rootNavigationScreen.value == RootNavigationScreen.AccountLinkingWaiting),
+                            (_rootNavigationScreen.value == RootNavigationScreen.AccountCreationWaiting || _rootNavigationScreen.value == RootNavigationScreen.AccountLinkingWaiting || _rootNavigationScreen.value is RootNavigationScreen.WelcomeToLetro),
                     )
                     !contactsState.isPairedContactExist && conversations.isEmpty() -> RootNavigationScreen.NoContactsScreen
                     else -> RootNavigationScreen.Home


### PR DESCRIPTION
We should keep the equal WelcomeToLetro instance when pair request was sent, but not acknowledged yet (isPairRequestWasEverSent = true) to prevent replacing root navigation screen without acknowledging pairing request.